### PR TITLE
Create haproxy.with.admin.stats.ui.cfg

### DIFF
--- a/configuration/haproxy.with.admin.stats.ui.cfg
+++ b/configuration/haproxy.with.admin.stats.ui.cfg
@@ -1,0 +1,72 @@
+global
+    # To have these messages end up in /var/log/haproxy.log you will
+    # need to:
+    #
+    # 1) configure syslog to accept network log events.  This is done
+    #    by adding the '-r' option to the SYSLOGD_OPTIONS in
+    #    /etc/sysconfig/syslog
+    #
+    # 2) configure local2 events to go to the /var/log/haproxy.log
+    #   file. A line like the following can be added to
+    #   /etc/sysconfig/syslog
+    #
+    #    local2.*                       /var/log/haproxy.log
+    #
+    log         127.0.0.1 local0
+    log         127.0.0.1 local1 notice
+    chroot      /var/lib/haproxy
+    pidfile     /var/run/haproxy.pid
+    maxconn     4000
+    user        haproxy
+    group       haproxy
+    daemon
+
+    # turn on stats unix socket
+    #stats socket /var/lib/haproxy/stats
+
+#---------------------------------------------------------------------
+# common defaults that all the 'listen' and 'backend' sections will
+# use if not designated in their block
+#
+# You might need to adjust timing values to prevent timeouts.
+#---------------------------------------------------------------------
+defaults
+    mode                    http
+    log                     global
+    option                  httplog
+    option                  dontlognull
+    option http-server-close
+    option forwardfor       except 127.0.0.0/8
+    option                  redispatch
+    retries                 3
+    maxconn                 3000
+    contimeout 5000
+    clitimeout 50000
+    srvtimeout 50000
+
+#
+# This sets up the admin page for HA Proxy at port 25002.
+#
+listen stats
+    bind *:25002
+    balance
+    mode http
+    stats enable
+    stats uri /
+#.  uncomment the below line to enable the authentication for stats ui(http://<LB_HOST>:25002)
+#   stats auth admin:admin
+
+
+# This is the setup for HS2. beeline client connect to load_balancer_host:10000.
+# HAProxy will balance connections among the list of servers listed below.
+listen hiveserver2_lb
+    bind *:10000
+    mode tcp
+    option tcplog
+    balance source
+    cookie SRVNAME insert
+
+server c249-node2 c249-node2.example.com:10000 cookie Sc249-node2 check
+server c249-node3 c249-node3.example.com:10000 cookie Sc249-node3 check
+server c249-node4 c249-node4.example.com:10000 cookie Sc249-node4 check
+server c249-node5 c249-node5.example.com:10000 cookie Sc249-node5 check


### PR DESCRIPTION
This sample config enables HAPROXY stats information in a UI on the URL http://<LB_HOST>:25002